### PR TITLE
fixed main.js location after gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,7 +35,7 @@ function bundleShare (b) {
   b.bundle()
     .on('error', handleError)
     .pipe(source('main.js'))
-    .pipe(gulp.dest('dist/'))
+    .pipe(gulp.dest('dist/js/'))
 }
 
 gulp.task('browserify', function () {


### PR DESCRIPTION
When run `gulp`, the `main.js` file should be in `dist/js/` rather than `dist/`.