### PR TITLE
2px outline around the main game board

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,9 @@
         height: 21px;
         border: 1px solid #ddd;
       }
+      .game-board {
+          outline: 2px solid black;
+      }
       .piece-view {
         margin-bottom: 12px;
       }


### PR DESCRIPTION
Sometimes, when the user's attention is focused on the main game board, it's easy to not notice that not all the columns have been filled till the board fills up a lot. At that time, it's either too late or quite late(the user has to make do with non-optimal pieces).

A simple outline to mitigate the issue.

![image](https://user-images.githubusercontent.com/14993220/120940609-c1010700-c73b-11eb-9599-eb62a27cb8eb.png)
